### PR TITLE
about: add image zoom, research papers, reorder sections, reduce page…

### DIFF
--- a/mcp-security-checklist/src/components/pages/AboutPage.tsx
+++ b/mcp-security-checklist/src/components/pages/AboutPage.tsx
@@ -1,11 +1,28 @@
-import { ArrowLeft } from 'lucide-react'
+import { useEffect, useState } from 'react'
+import { ArrowLeft, X, ZoomIn } from 'lucide-react'
 
+import mcpAttackSurface from '@/assets/img/mcpattacksurface.png'
 import { Button } from '@/components/ui/button'
 
 export function AboutPage() {
+  const [isZoomed, setIsZoomed] = useState(false)
+
+  useEffect(() => {
+    window.scrollTo(0, 0)
+  }, [])
+
+  useEffect(() => {
+    if (!isZoomed) return
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setIsZoomed(false)
+    }
+    window.addEventListener('keydown', handleKey)
+    return () => window.removeEventListener('keydown', handleKey)
+  }, [isZoomed])
+
   return (
     <div className="animate-page-enter">
-      <div className="mx-auto max-w-[var(--page-width)] px-6 py-16 md:px-[var(--page-padding)] md:py-24">
+      <div className="mx-auto max-w-[var(--page-width)] px-6 py-8 md:px-[var(--page-padding)] md:py-12">
         <Button
           asChild
           className="mb-8 h-9 rounded-sm border border-transparent bg-transparent px-3 font-normal text-foreground hover:border-border hover:bg-transparent hover:text-foreground dark:hover:bg-transparent dark:hover:text-foreground"
@@ -32,24 +49,6 @@ export function AboutPage() {
             data sources, and services. With this power comes significant security responsibility —
             from API validation and tool integrity to agentic workflow safety and governance compliance.
           </p>
-
-          <h2 className="pt-4 font-normal text-foreground" style={{ fontSize: 'var(--font-size-title)', lineHeight: 'var(--line-height-title)' }}>
-            Sources & methodology
-          </h2>
-
-          <p>
-            This checklist synthesizes security guidance from multiple authoritative sources:
-          </p>
-
-          <ul className="list-disc space-y-2 pl-6">
-            <li>OWASP Secure MCP Server Development Guide v1.0 (Feb 2026)</li>
-            <li>OWASP Cheat Sheet for Third-Party MCP Servers v1.0</li>
-            <li>OWASP Top 10 for Agentic Applications 2026</li>
-            <li>OWASP LLM AI Security & Governance Checklist v1.1</li>
-            <li>OWASP AI Red Teaming Vendor Evaluation Guide v1.0</li>
-            <li>SlowMist MCP-Security-Checklist (2025)</li>
-            <li>Recent academic research (arXiv 2506.01333, 2506.02040, 2512.06556, 2505.14590)</li>
-          </ul>
 
           <h2 className="pt-4 font-normal text-foreground" style={{ fontSize: 'var(--font-size-title)', lineHeight: 'var(--line-height-title)' }}>
             Priority levels
@@ -81,10 +80,155 @@ export function AboutPage() {
           </p>
 
           <p>
-            The checklist covers 228 security controls across 7 domains, from MCP server hardening
-            to cryptocurrency-specific protections. Section 8 provides reference tooling recommendations
+            The checklist covers 200+ security controls across 7 domains, from MCP client or server hardening
+            to architectural considerations. Section 8 provides reference tooling recommendations
             and is not part of the scored checklist.
           </p>
+
+          <figure className="group relative mt-6 overflow-hidden rounded-md border border-[var(--border)]" style={{ marginLeft: 'calc(-1 * var(--page-padding, 2rem))', marginRight: 'calc(-1 * var(--page-padding, 2rem))', width: 'calc(100% + 2 * var(--page-padding, 2rem))' }}>
+            <button
+              aria-label="Zoom image"
+              className="absolute right-2 top-2 flex h-7 w-7 items-center justify-center rounded-sm bg-black/50 text-white opacity-0 transition-opacity hover:bg-black/70 group-hover:opacity-100"
+              onClick={() => setIsZoomed(true)}
+              type="button"
+            >
+              <ZoomIn className="size-4" />
+            </button>
+            <img
+              alt="MCP attack surface diagram illustrating the threat landscape across protocol layers"
+              className="w-full cursor-zoom-in object-contain"
+              onClick={() => setIsZoomed(true)}
+              src={mcpAttackSurface}
+            />
+            <figcaption className="border-t border-[var(--border)] px-4 py-2 text-center text-xs text-[var(--foreground-secondary)]">
+              MCP attack surface across protocol layers — from{' '}
+              <a
+                className="text-[var(--accent)] underline underline-offset-2 transition-colors hover:text-[var(--accent-hover)]"
+                href="https://arxiv.org/abs/2508.13220"
+                rel="noreferrer"
+                target="_blank"
+              >
+                MCPSecBench (arXiv:2508.13220)
+              </a>
+            </figcaption>
+          </figure>
+
+          {isZoomed && (
+            <div
+              className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 p-4 backdrop-blur-sm"
+              onClick={() => setIsZoomed(false)}
+            >
+              <button
+                aria-label="Close zoom"
+                className="absolute right-4 top-4 flex h-8 w-8 items-center justify-center rounded-sm bg-white/10 text-white transition-colors hover:bg-white/20"
+                onClick={() => setIsZoomed(false)}
+                type="button"
+              >
+                <X className="size-5" />
+              </button>
+              <img
+                alt="MCP attack surface diagram illustrating the threat landscape across protocol layers"
+                className="max-h-full max-w-full cursor-zoom-out rounded-md object-contain shadow-2xl"
+                onClick={(e) => e.stopPropagation()}
+                src={mcpAttackSurface}
+              />
+            </div>
+          )}
+
+          <h2 className="pt-4 font-normal text-foreground" style={{ fontSize: 'var(--font-size-title)', lineHeight: 'var(--line-height-title)' }}>
+            Sources & methodology
+          </h2>
+
+          <p>
+            This checklist synthesizes security guidance from multiple authoritative sources:
+          </p>
+
+          <ul className="list-disc space-y-2 pl-6">
+            <li>OWASP Secure MCP Server Development Guide v1.0 (Feb 2026)</li>
+            <li>OWASP Cheat Sheet for Third-Party MCP Servers v1.0</li>
+            <li>OWASP Top 10 for Agentic Applications 2026</li>
+            <li>OWASP LLM AI Security & Governance Checklist v1.1</li>
+            <li>OWASP AI Red Teaming Vendor Evaluation Guide v1.0</li>
+            <li>SlowMist MCP-Security-Checklist (2025)</li>
+            <li>
+              <a
+                className="text-[var(--accent)] underline underline-offset-2 transition-colors hover:text-[var(--accent-hover)]"
+                href="https://arxiv.org/abs/2505.14590"
+                rel="noreferrer"
+                target="_blank"
+              >
+                arXiv:2505.14590
+              </a>
+              {' — '}
+              MCIP: Protecting MCP Safety via Model Contextual Integrity Protocol
+              {' (Jing et al., 2025)'}
+            </li>
+            <li>
+              <a
+                className="text-[var(--accent)] underline underline-offset-2 transition-colors hover:text-[var(--accent-hover)]"
+                href="https://arxiv.org/abs/2506.01333"
+                rel="noreferrer"
+                target="_blank"
+              >
+                arXiv:2506.01333
+              </a>
+              {' — '}
+              ETDI: Mitigating Tool Squatting and Rug Pull Attacks in Model Context Protocol (MCP) by using OAuth-Enhanced Tool Definitions and Policy-Based Access Control
+              {' (Bhatt, Narajala & Habler, 2025)'}
+            </li>
+            <li>
+              <a
+                className="text-[var(--accent)] underline underline-offset-2 transition-colors hover:text-[var(--accent-hover)]"
+                href="https://arxiv.org/abs/2506.02040"
+                rel="noreferrer"
+                target="_blank"
+              >
+                arXiv:2506.02040
+              </a>
+              {' — '}
+              Beyond the Protocol: Unveiling Attack Vectors in the Model Context Protocol (MCP) Ecosystem
+              {' (Song et al., 2025)'}
+            </li>
+            <li>
+              <a
+                className="text-[var(--accent)] underline underline-offset-2 transition-colors hover:text-[var(--accent-hover)]"
+                href="https://arxiv.org/abs/2512.06556"
+                rel="noreferrer"
+                target="_blank"
+              >
+                arXiv:2512.06556
+              </a>
+              {' — '}
+              Securing the Model Context Protocol: Defending LLMs Against Tool Poisoning and Adversarial Attacks
+              {' (Jamshidi et al., 2025)'}
+            </li>
+            <li>
+              <a
+                className="text-[var(--accent)] underline underline-offset-2 transition-colors hover:text-[var(--accent-hover)]"
+                href="https://arxiv.org/abs/2504.08623"
+                rel="noreferrer"
+                target="_blank"
+              >
+                arXiv:2504.08623
+              </a>
+              {' — '}
+              Enterprise-Grade Security for the Model Context Protocol (MCP): Frameworks and Mitigation Strategies
+              {' (Narajala & Habler, 2025)'}
+            </li>
+            <li>
+              <a
+                className="text-[var(--accent)] underline underline-offset-2 transition-colors hover:text-[var(--accent-hover)]"
+                href="https://arxiv.org/abs/2508.13220"
+                rel="noreferrer"
+                target="_blank"
+              >
+                arXiv:2508.13220
+              </a>
+              {' — '}
+              MCPSecBench: A Systematic Security Benchmark and Playground for Testing Model Context Protocols
+              {' (Yang et al., 2025)'}
+            </li>
+          </ul>
 
           <h2 className="pt-4 font-normal text-foreground" style={{ fontSize: 'var(--font-size-title)', lineHeight: 'var(--line-height-title)' }}>
             License

--- a/mcp-security-checklist/src/components/pages/SharePage.tsx
+++ b/mcp-security-checklist/src/components/pages/SharePage.tsx
@@ -42,7 +42,7 @@ export function SharePage() {
 
   return (
     <div className="animate-page-enter">
-      <div className="mx-auto max-w-[var(--page-width)] px-6 py-16 md:px-[var(--page-padding)] md:py-24">
+      <div className="mx-auto max-w-[var(--page-width)] px-6 py-8 md:px-[var(--page-padding)] md:py-12">
         <Button
           asChild
           className="mb-8 h-9 rounded-sm border border-transparent bg-transparent px-3 font-normal text-foreground hover:border-border hover:bg-transparent hover:text-foreground dark:hover:bg-transparent dark:hover:text-foreground"


### PR DESCRIPTION
… spacing

- Add mcpattacksurface.png with click-to-zoom lightbox (Escape/backdrop to close)
- Expand sources list with 6 linked arXiv papers (2504.08623, 2505.14590, 2506.01333, 2506.02040, 2508.13220, 2512.06556)
- Reorder page: Priority levels → How it works → Image → Sources & methodology
- Reduce top padding (py-16 md:py-24 → py-8 md:py-12) on About and Share pages
- Scroll to top on About page mount